### PR TITLE
Delay adding helper method to on_load

### DIFF
--- a/lib/rails-jquery-autocomplete.rb
+++ b/lib/rails-jquery-autocomplete.rb
@@ -10,8 +10,15 @@ module RailsJQueryAutocomplete
   end
 end
 
-class ActionController::Base
-  include RailsJQueryAutocomplete::Autocomplete
+if Rails::VERSION::MAJOR >= 6
+  ActiveSupport.on_load(:action_controller_base) do
+    ActionController::Base.send(
+      :include,
+      RailsJQueryAutocomplete::Autocomplete
+    )
+  end
+else
+  ActionController::Base.send(:include, RailsJQueryAutocomplete::Autocomplete)
 end
 
 require 'rails-jquery-autocomplete/formtastic'


### PR DESCRIPTION
Autoloading within initilizers is deprecated in rails 6.0.

Adding helper method to ActionController::Base during initialization
will trigger autoloading it.

This delays adding the helper methods using an on_load() hook for
all rails version >= 6.