### PR TITLE
Fix deprecation warning dangerous query method

### DIFF
--- a/lib/rails-jquery-autocomplete/orm/active_record.rb
+++ b/lib/rails-jquery-autocomplete/orm/active_record.rb
@@ -3,15 +3,17 @@ module RailsJQueryAutocomplete
     module ActiveRecord
       def active_record_get_autocomplete_order(method, options, model=nil)
         order = options[:order]
+        table_prefix = model ? "#{model.table_name}." : ''
+        term_method = method.to_s
+        term_aggregate = "#{table_prefix}#{method}"
 
-        table_prefix = model ? "#{model.table_name}." : ""
         sql = if sqlite?
-          order || "LOWER(#{method}) ASC"
-        else
-          order || "LOWER(#{table_prefix}#{method}) ASC"
-        end
+                Arel.sql("LOWER(#{term_method}) ASC")
+              else
+                Arel.sql("LOWER(#{term_aggregate}) ASC")
+              end
+        Arel.sql(order || sql)
 
-        Arel.sql(sql)
       end
 
       def active_record_get_autocomplete_items(parameters)

--- a/rails-jquery-autocomplete.gemspec
+++ b/rails-jquery-autocomplete.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rails', '>= 3.2')
 
-  s.add_development_dependency 'sqlite3-ruby'
+  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mongoid',      '>= 2.0.0'
   s.add_development_dependency 'mongo_mapper', '>= 0.9'


### PR DESCRIPTION


This fixes deprecation warning: 
```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "LOWER(model.method) ASC". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql()
```